### PR TITLE
Missing config params on SFT

### DIFF
--- a/recipes/zephyr-7b-beta/README.md
+++ b/recipes/zephyr-7b-beta/README.md
@@ -9,7 +9,7 @@ As described in the Zephyr [technical report](https://huggingface.co/papers/2310
 See below for commands to train these models using either DeepSpeed ZeRO-3 or LoRA.
 
 ## Full training examples
-
+You will require 8 GPUs (80GB of VRAM) to train the full model.
 ```shell
 # Step 1 - SFT
 ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/deepspeed_zero3.yaml scripts/run_sft.py recipes/zephyr-7b-beta/sft/config_full.yaml

--- a/recipes/zephyr-7b-beta/sft/config_lora.yaml
+++ b/recipes/zephyr-7b-beta/sft/config_lora.yaml
@@ -37,8 +37,9 @@ log_level: info
 logging_steps: 5  
 logging_strategy: steps
 lr_scheduler_type: cosine
+warmup_ratio: 0.1
 max_seq_length: 2048
-max_steps: -1
+max_steps: 272
 num_train_epochs: 1
 output_dir: data/zephyr-7b-sft-lora
 overwrite_output_dir: true

--- a/recipes/zephyr-7b-beta/sft/config_lora.yaml
+++ b/recipes/zephyr-7b-beta/sft/config_lora.yaml
@@ -37,9 +37,8 @@ log_level: info
 logging_steps: 5  
 logging_strategy: steps
 lr_scheduler_type: cosine
-warmup_ratio: 0.1
 max_seq_length: 2048
-max_steps: 272
+max_steps: -1
 num_train_epochs: 1
 output_dir: data/zephyr-7b-sft-lora
 overwrite_output_dir: true


### PR DESCRIPTION
Hi,
Small PR to add the missing warmup and the total number of steps so the training happens correctly.
I am also adding info on the GPU requirements ( 80GB Gpus ). <- this is on the main readme =P

<img width="1258" alt="image" src="https://github.com/huggingface/alignment-handbook/assets/18441985/09311346-83f3-4ded-a266-e2ccfcf827cb">

The [link to the experiment](https://wandb.ai/capecape/zephyr/workspace)
