### PR TITLE
Add check that parameters are not intended to be offloaded

### DIFF
--- a/scripts/run_dpo.py
+++ b/scripts/run_dpo.py
@@ -105,13 +105,17 @@ def main():
     torch_dtype = (
         model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
     )
+    params_offloaded = False
+    if accelerator.state.deepspeed_plugin and accelerator.state.deepspeed_plugin.offload_param_device != "none":
+        params_offloaded = True
+
     model_kwargs = dict(
         revision=model_args.model_revision,
         trust_remote_code=model_args.trust_remote_code,
         use_flash_attention_2=model_args.use_flash_attention_2,
         torch_dtype=torch_dtype,
         use_cache=False if training_args.gradient_checkpointing else True,
-        device_map=get_kbit_device_map(),
+        device_map=get_kbit_device_map() if not params_offloaded else None,
         quantization_config=get_quantization_config(model_args),
     )
 

--- a/scripts/run_sft.py
+++ b/scripts/run_sft.py
@@ -109,6 +109,9 @@ def main():
     torch_dtype = (
         model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
     )
+    params_offloaded = False
+    if accelerator.state.deepspeed_plugin and accelerator.state.deepspeed_plugin.offload_param_device != "none":
+        params_offloaded = True
 
     model_kwargs = dict(
         revision=model_args.model_revision,
@@ -116,7 +119,7 @@ def main():
         use_flash_attention_2=model_args.use_flash_attention_2,
         torch_dtype=torch_dtype,
         use_cache=False if training_args.gradient_checkpointing else True,
-        device_map=get_kbit_device_map(),
+        device_map=get_kbit_device_map() if not params_offloaded else None,
         quantization_config=get_quantization_config(model_args),
     )
     logger.info("*** Model loaded! ***")


### PR DESCRIPTION
I'm using the (awesome) script setups and data utilities. However I am not in an HPC environment (so launching multi-node without Slurm), and am using custom configs (both accelerate and deepspeed). 

I noticed that when using ZeRO 3 with CPU offloading, due to the current device map setting, I am still getting OOMs when setting batch sizes to the same that I usually would with the native `deepspeed` multi-node launcher. I believe this is because the model parameters are explicitly being put on the GPUs, consuming significant VRAM.

My understanding is that `from_pretrained` is made to cater to a deepspeed setup, and handles device placement and model parallelism in the offloading case. This PR adds a quick check confirming:
* Does the accelerator have a deepspeed plugin
* If it does, has the `offload_param_device` been set (I don't explicitly check for `cpu` since `nvme` is also valid though less common)

If it is set, device map is kept None in the init kwargs. From testing on my use case I've been able to increase the batch sizes back to what I expect to work with success, and VRAM usage seems to be spread evenly across any nodes.

Let me know if there are problems with the PR. I ran `style` and `quality` from the Makefile before pushing.