### PR TITLE
Allow loading datasets from disk using `load_from_disk` method.

### DIFF
--- a/src/alignment/data.py
+++ b/src/alignment/data.py
@@ -12,11 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import re
 from typing import List, Literal, Optional
 
-from datasets import DatasetDict, concatenate_datasets, load_dataset
+from datasets import DatasetDict, concatenate_datasets, load_dataset, load_from_disk
+
+from huggingface_hub.utils import HFValidationError
 
 from .configs import DataArguments
 
@@ -145,20 +147,17 @@ def mix_datasets(dataset_mixer: dict, splits: Optional[List[str]] = None, shuffl
     for ds, frac in dataset_mixer.items():
         fracs.append(frac)
         for split in splits:
+            try:
+                # Try first if dataset on a Hub repo
+                dataset = load_dataset(ds, split=split)
+            except HFValidationError:
+                # If not, check local dataset
+                dataset = load_from_disk(os.path.join(ds, split))
+
             if "train" in split:
-                raw_train_datasets.append(
-                    load_dataset(
-                        ds,
-                        split=split,
-                    )
-                )
+                raw_train_datasets.append(dataset)
             elif "test" in split:
-                raw_val_datasets.append(
-                    load_dataset(
-                        ds,
-                        split=split,
-                    )
-                )
+                raw_val_datasets.append(dataset)
             else:
                 raise ValueError(f"Split type {split} not recognized as one of test or train.")
 

--- a/src/alignment/data.py
+++ b/src/alignment/data.py
@@ -17,8 +17,7 @@ import re
 from typing import List, Literal, Optional
 
 from datasets import DatasetDict, concatenate_datasets, load_dataset, load_from_disk
-
-from huggingface_hub.utils import HFValidationError
+from datasets.builder import DatasetGenerationError
 
 from .configs import DataArguments
 
@@ -150,7 +149,7 @@ def mix_datasets(dataset_mixer: dict, splits: Optional[List[str]] = None, shuffl
             try:
                 # Try first if dataset on a Hub repo
                 dataset = load_dataset(ds, split=split)
-            except HFValidationError:
+            except DatasetGenerationError:
                 # If not, check local dataset
                 dataset = load_from_disk(os.path.join(ds, split))
 


### PR DESCRIPTION
If a dataset is created with `ds.save_to_disk()`, `load_dataset()` fails to load the local dataset and throws errors. The solution could be either providing a custom loading script, or maybe using `load_from_disk` method as proposed in this PR. The dataset is stored using `.arrow` format and the splits are stored in separate folders (E.g.: `ds.save_to_disk(os.path.join(path, dataset_name))`).

Starting the training later is done by adapting the `config` files with:

```
dataset_mixer:
  /path/to/my/dataset/: 1.0
dataset_splits:
- train_sft
- test_sft
```