### PR TITLE
Make max samples work again

### DIFF
--- a/src/alignment/data.py
+++ b/src/alignment/data.py
@@ -124,6 +124,13 @@ def get_datasets(
         raise ValueError(f"Data config {data_config} not recognized.")
 
     raw_datasets = mix_datasets(dataset_mixer, splits=splits, shuffle=shuffle)
+
+    if type(data_config) is DataArguments:
+        if data_config.max_train_samples is not None:
+            raw_datasets['train'] = raw_datasets['train'].select(range(data_config.max_train_samples))
+        if data_config.max_eval_samples is not None:
+            raw_datasets['test'] = raw_datasets['test'].select(range(data_config.max_eval_samples))
+
     return raw_datasets
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -79,6 +79,17 @@ class GetDatasetsTest(unittest.TestCase):
         self.assertEqual(len(datasets["test"]), 100)
         self.assertRaises(KeyError, lambda: datasets["train"])
 
+    def test_max_samples(self):
+        dataset_mixer = {
+            "HuggingFaceH4/testing_alpaca_small": 0.5,
+            "HuggingFaceH4/testing_self_instruct_small": 0.3,
+            "HuggingFaceH4/testing_codealpaca_small": 0.2,
+        }
+        data_args = DataArguments(dataset_mixer=dataset_mixer, max_train_samples=42, max_eval_samples=69)
+        datasets = get_datasets(data_args)
+        self.assertEqual(len(datasets["train"]), 42)
+        self.assertEqual(len(datasets["test"]), 69)
+
 
 class ApplyChatTemplateTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
There are parameters `max_train_samples` and `max_eval_samples` in DataArguments, but if you put them in config, nothing changes. I look at the code,  they don't appear anywhere beside logging. 

This PR makes them behave as described in config help
"For debugging purposes or quicker training, truncate the number of evaluation examples to this value if set.""
