### PR TITLE
Make SFT script consistent with DPO script

### DIFF
--- a/scripts/run_sft.py
+++ b/scripts/run_sft.py
@@ -95,11 +95,13 @@ def main():
     #####################
     # Apply chat template
     #####################
-    raw_datasets = raw_datasets.map(apply_chat_template,
-                                    fn_kwargs={"tokenizer": tokenizer, "task": "sft"},
-                                    num_proc=data_args.preprocessing_num_workers,
-                                    remove_columns=column_names,
-                                    desc="Applying chat template",)
+    raw_datasets = raw_datasets.map(
+        apply_chat_template,
+        fn_kwargs={"tokenizer": tokenizer, "task": "sft"},
+        num_proc=data_args.preprocessing_num_workers,
+        remove_columns=column_names,
+        desc="Applying chat template",
+    )
     train_dataset = raw_datasets["train"]
     eval_dataset = raw_datasets["test"]
 

--- a/scripts/run_sft.py
+++ b/scripts/run_sft.py
@@ -94,7 +94,7 @@ def main():
     #####################
     # Apply chat template
     #####################
-    raw_datasets = raw_datasets.map(apply_chat_template, fn_kwargs={"tokenizer": tokenizer, "task": "sft"})
+    raw_datasets = raw_datasets.map(apply_chat_template, num_proc=data_args.preprocessing_num_workers, fn_kwargs={"tokenizer": tokenizer, "task": "sft"})
     train_dataset = raw_datasets["train"]
     eval_dataset = raw_datasets["test"]
 

--- a/scripts/run_sft.py
+++ b/scripts/run_sft.py
@@ -85,6 +85,7 @@ def main():
     logger.info(
         f"Training on the following datasets and their proportions: {[split + ' : ' + str(dset.num_rows) for split, dset in raw_datasets.items()]}"
     )
+    column_names = list(raw_datasets["train"].features)
 
     ################
     # Load tokenizer
@@ -94,7 +95,11 @@ def main():
     #####################
     # Apply chat template
     #####################
-    raw_datasets = raw_datasets.map(apply_chat_template, num_proc=data_args.preprocessing_num_workers, fn_kwargs={"tokenizer": tokenizer, "task": "sft"})
+    raw_datasets = raw_datasets.map(apply_chat_template,
+                                    fn_kwargs={"tokenizer": tokenizer, "task": "sft"},
+                                    num_proc=data_args.preprocessing_num_workers,
+                                    remove_columns=column_names,
+                                    desc="Applying chat template",)
     train_dataset = raw_datasets["train"]
     eval_dataset = raw_datasets["test"]
 


### PR DESCRIPTION
The SFT script currently doesn't pass the `num_proc` argument as in the DPO script, which I've added.

I've also added `remove_columns` and `desc` similar to the DPO script.