### PR TITLE
Add check before inserting system message

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+from copy import deepcopy
 
 import pytest
 from datasets import Dataset
@@ -127,8 +128,8 @@ class ApplyChatTemplateTest(unittest.TestCase):
         llama_tokenizer = AutoTokenizer.from_pretrained("codellama/CodeLlama-7b-hf")
         messages_sys_excl = [{"role": "user", "content": "Tell me a joke."}]
         messages_sys_incl = [{"role": "system", "content": ""}, {"role": "user", "content": "Tell me a joke."}]
-        mistral_output = maybe_insert_system_message(messages_sys_excl, mistral_tokenizer)
-        llama_output = maybe_insert_system_message(messages_sys_excl, llama_tokenizer)
+        mistral_output = maybe_insert_system_message(deepcopy(messages_sys_excl), mistral_tokenizer)
+        llama_output = maybe_insert_system_message(deepcopy(messages_sys_excl), llama_tokenizer)
 
         # output from mistral should not have a system message, output from llama should
         self.assertEqual(mistral_output, messages_sys_excl)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -128,12 +128,15 @@ class ApplyChatTemplateTest(unittest.TestCase):
         llama_tokenizer = AutoTokenizer.from_pretrained("codellama/CodeLlama-7b-hf")
         messages_sys_excl = [{"role": "user", "content": "Tell me a joke."}]
         messages_sys_incl = [{"role": "system", "content": ""}, {"role": "user", "content": "Tell me a joke."}]
-        mistral_output = maybe_insert_system_message(deepcopy(messages_sys_excl), mistral_tokenizer)
-        llama_output = maybe_insert_system_message(deepcopy(messages_sys_excl), llama_tokenizer)
+
+        mistral_messages = deepcopy(messages_sys_excl)
+        llama_messages = deepcopy(messages_sys_excl)
+        maybe_insert_system_message(mistral_messages, mistral_tokenizer)
+        maybe_insert_system_message(llama_messages, llama_tokenizer)
 
         # output from mistral should not have a system message, output from llama should
-        self.assertEqual(mistral_output, messages_sys_excl)
-        self.assertEqual(llama_output, messages_sys_incl)
+        self.assertEqual(mistral_messages, messages_sys_excl)
+        self.assertEqual(llama_messages, messages_sys_incl)
 
     def test_sft(self):
         dataset = self.dataset.map(


### PR DESCRIPTION
This should solve https://github.com/huggingface/alignment-handbook/issues/101. Currently an empty system message is always inserted if there is not one. Some tokenizers do not accept a system message.

Not sure this message is foolproof, but this checks the jinja template string for a mention of `system` before inserting. Includes unit test.

May also solve https://github.com/huggingface/alignment-handbook/issues/93 according to @Feynman27 but I have not confirmed.