### PR TITLE
Add `auto_insert_empty_system_msg` config flag

### DIFF
--- a/scripts/run_dpo.py
+++ b/scripts/run_dpo.py
@@ -93,7 +93,7 @@ def main():
     #####################
     raw_datasets = raw_datasets.map(
         apply_chat_template,
-        fn_kwargs={"tokenizer": tokenizer, "task": "dpo"},
+        fn_kwargs={"tokenizer": tokenizer, "task": "dpo", "auto_insert_empty_system_msg": data_args.auto_insert_empty_system_msg},
         num_proc=data_args.preprocessing_num_workers,
         remove_columns=column_names,
         desc="Formatting comparisons with prompt template",

--- a/scripts/run_dpo.py
+++ b/scripts/run_dpo.py
@@ -93,7 +93,11 @@ def main():
     #####################
     raw_datasets = raw_datasets.map(
         apply_chat_template,
-        fn_kwargs={"tokenizer": tokenizer, "task": "dpo", "auto_insert_empty_system_msg": data_args.auto_insert_empty_system_msg},
+        fn_kwargs={
+            "tokenizer": tokenizer,
+            "task": "dpo",
+            "auto_insert_empty_system_msg": data_args.auto_insert_empty_system_msg,
+        },
         num_proc=data_args.preprocessing_num_workers,
         remove_columns=column_names,
         desc="Formatting comparisons with prompt template",

--- a/scripts/run_sft.py
+++ b/scripts/run_sft.py
@@ -100,7 +100,11 @@ def main():
     #####################
     raw_datasets = raw_datasets.map(
         apply_chat_template,
-        fn_kwargs={"tokenizer": tokenizer, "task": "sft", "auto_insert_empty_system_msg": data_args.auto_insert_empty_system_msg},
+        fn_kwargs={
+            "tokenizer": tokenizer,
+            "task": "sft",
+            "auto_insert_empty_system_msg": data_args.auto_insert_empty_system_msg,
+        },
         num_proc=data_args.preprocessing_num_workers,
         remove_columns=column_names,
         desc="Applying chat template",

--- a/scripts/run_sft.py
+++ b/scripts/run_sft.py
@@ -100,7 +100,7 @@ def main():
     #####################
     raw_datasets = raw_datasets.map(
         apply_chat_template,
-        fn_kwargs={"tokenizer": tokenizer, "task": "sft"},
+        fn_kwargs={"tokenizer": tokenizer, "task": "sft", "auto_insert_empty_system_msg": data_args.auto_insert_empty_system_msg},
         num_proc=data_args.preprocessing_num_workers,
         remove_columns=column_names,
         desc="Applying chat template",

--- a/src/alignment/configs.py
+++ b/src/alignment/configs.py
@@ -208,7 +208,7 @@ class DataArguments:
         default=True,
         metadata={
             "help": (
-                "Whether to automatically insert an empty system message as the first messageif `system` is mentioned in the chat template."
+                "Whether to automatically insert an empty system message as the first message if `system` is mentioned in the chat template."
             )
         },
     )

--- a/src/alignment/configs.py
+++ b/src/alignment/configs.py
@@ -204,6 +204,14 @@ class DataArguments:
     truncation_side: Optional[str] = field(
         default=None, metadata={"help": "Truncation side to use for the tokenizer."}
     )
+    auto_insert_empty_system_msg: bool = field(
+        default=True,
+        metadata={
+            "help": (
+                "Whether to automatically insert an empty system message as the first messageif `system` is mentioned in the chat template."
+            )
+        },
+    )
 
 
 @dataclass

--- a/src/alignment/data.py
+++ b/src/alignment/data.py
@@ -75,7 +75,7 @@ def apply_chat_template(
             # Prepend a system message if the first message is not a system message
             if auto_insert_empty_system_msg:
                 maybe_insert_system_message(prompt_messages, tokenizer)
-                
+
             # Now we extract the final turn to define chosen/rejected responses
             chosen_messages = example["chosen"][-1:]
             rejected_messages = example["rejected"][-1:]

--- a/src/alignment/data.py
+++ b/src/alignment/data.py
@@ -42,11 +42,13 @@ def apply_chat_template(
     example,
     tokenizer,
     task: Literal["sft", "generation", "rm", "dpo"],
+    auto_insert_empty_system_msg: bool = True,
 ):
     if task in ["sft", "generation"]:
         messages = example["messages"]
         # We add an empty system message if there is none
-        maybe_insert_system_message(messages, tokenizer)
+        if auto_insert_empty_system_msg:
+            maybe_insert_system_message(messages, tokenizer)
         example["text"] = tokenizer.apply_chat_template(
             messages, tokenize=False, add_generation_prompt=True if task == "generation" else False
         )
@@ -55,8 +57,9 @@ def apply_chat_template(
             chosen_messages = example["chosen"]
             rejected_messages = example["rejected"]
             # We add an empty system message if there is none
-            maybe_insert_system_message(chosen_messages, tokenizer)
-            maybe_insert_system_message(rejected_messages, tokenizer)
+            if auto_insert_empty_system_msg:
+                maybe_insert_system_message(chosen_messages, tokenizer)
+                maybe_insert_system_message(rejected_messages, tokenizer)
 
             example["text_chosen"] = tokenizer.apply_chat_template(chosen_messages, tokenize=False)
             example["text_rejected"] = tokenizer.apply_chat_template(rejected_messages, tokenize=False)
@@ -70,8 +73,9 @@ def apply_chat_template(
             # We therefore need to extract the N-1 turns to form the prompt
             prompt_messages = example["chosen"][:-1]
             # Prepend a system message if the first message is not a system message
-            if example["chosen"][0]["role"] != "system":
-                prompt_messages.insert(0, {"role": "system", "content": ""})
+            if auto_insert_empty_system_msg:
+                maybe_insert_system_message(prompt_messages, tokenizer)
+                
             # Now we extract the final turn to define chosen/rejected responses
             chosen_messages = example["chosen"][-1:]
             rejected_messages = example["rejected"][-1:]


### PR DESCRIPTION
Currently there is functionality to automatically insert an empty system message if `system` occur in the Jinja template.

https://github.com/huggingface/alignment-handbook/blob/87cc800498b17432cfb7f5acb5e9a79f15c867fc/src/alignment/data.py#L27-L38

This is not  foolproof method: GEMMA (SFT) for instance has an explicit part in its chat template that says that if the role is "system" that an error must be raised. So this leads to a conflict with the alignment handbook. Therefore I suggest giving all control to the user but doing so in a backwards-compatible manner: by adding a flag that, if True, adds the system message with the same behavior as before, and when False no system message will be added. To this end, `auto_insert_empty_system_msg` is added as a DataArguments argument (defaulting to True).

Note that there is one small breaking change: the `maybe_insert_system_message` is currently implemented only for sft, generation and rm, but it was not used for dpo. There, a system message was ALWAYS added if the first message was not system, even if the Jinja template did not mention system. I changed that to be in line with the other tasks so the default behavior will be a litttle bit different when a tokenizer's chat template does not contain 'system' in DPO.