### PR TITLE
Fix text_chosen and text_rejected

### DIFF
--- a/src/alignment/data.py
+++ b/src/alignment/data.py
@@ -77,11 +77,9 @@ def apply_chat_template(
                 maybe_insert_system_message(prompt_messages, tokenizer)
 
             # Now we extract the final turn to define chosen/rejected responses
-            chosen_messages = example["chosen"][-1:]
-            rejected_messages = example["rejected"][-1:]
-            example["text_chosen"] = tokenizer.apply_chat_template(chosen_messages, tokenize=False)
-            example["text_rejected"] = tokenizer.apply_chat_template(rejected_messages, tokenize=False)
             example["text_prompt"] = tokenizer.apply_chat_template(prompt_messages, tokenize=False)
+            example["text_chosen"] = tokenizer.apply_chat_template(example["chosen"], tokenize=False)[len(example["text_prompt"]):]
+            example["text_rejected"] = tokenizer.apply_chat_template(example["rejected"], tokenize=False)[len(example["text_prompt"]):]
         else:
             raise ValueError(
                 f"Could not format example as dialogue for `dpo` task! Require `[chosen, rejected]` keys but found {list(example.keys())}"


### PR DESCRIPTION
We do not directly create `text_chosen` from `chosen_messages` (same for rejected), as `chosen_messages` contains only an assistant message and it may raise jinja error (`raise_exception('Conversation roles must alternate user/assistant/user/assistant/...')`) in many chat models' chat_template ([example](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/blob/c1b0db933684edbfe29a06fa47eb19cc48025e93/tokenizer_config.json#L12). Instead, we remove the prompt part from the whole `chosen_messages`'s input text.