### PR TITLE
Fix dataloading for cpt

### DIFF
--- a/scripts/run_cpt.py
+++ b/scripts/run_cpt.py
@@ -83,7 +83,12 @@ def main():
     ###############
     # Load datasets
     ###############
-    raw_datasets = get_datasets(data_args, splits=data_args.dataset_splits, configs=data_args.dataset_configs)
+    raw_datasets = get_datasets(
+        data_args,
+        splits=data_args.dataset_splits,
+        configs=data_args.dataset_configs,
+        text_column=data_args.text_column,
+    )
 
     logger.info(
         f"Training on the following datasets and their proportions:"

--- a/scripts/run_cpt.py
+++ b/scripts/run_cpt.py
@@ -87,7 +87,7 @@ def main():
         data_args,
         splits=data_args.dataset_splits,
         configs=data_args.dataset_configs,
-        text_column=data_args.text_column,
+        columns_to_keep=[data_args.text_column],
     )
 
     logger.info(

--- a/scripts/run_dpo.py
+++ b/scripts/run_dpo.py
@@ -77,7 +77,12 @@ def main():
     ###############
     # Load datasets
     ###############
-    raw_datasets = get_datasets(data_args, splits=data_args.dataset_splits, configs=data_args.dataset_configs)
+    raw_datasets = get_datasets(
+        data_args,
+        splits=data_args.dataset_splits,
+        configs=data_args.dataset_configs,
+        columns_to_keep=["messages", "chosen", "rejected", "prompt", "completion", "label"],
+    )
     logger.info(
         f"Training on the following splits: {[split + ' : ' + str(dset.num_rows) for split, dset in raw_datasets.items()]}"
     )

--- a/scripts/run_sft.py
+++ b/scripts/run_sft.py
@@ -85,7 +85,12 @@ def main():
     ###############
     # Load datasets
     ###############
-    raw_datasets = get_datasets(data_args, splits=data_args.dataset_splits, configs=data_args.dataset_configs)
+    raw_datasets = get_datasets(
+        data_args,
+        splits=data_args.dataset_splits,
+        configs=data_args.dataset_configs,
+        columns_to_keep=["messages", "chosen", "rejected", "prompt", "completion", "label"],
+    )
     logger.info(
         f"Training on the following datasets and their proportions: {[split + ' : ' + str(dset.num_rows) for split, dset in raw_datasets.items()]}"
     )

--- a/src/alignment/data.py
+++ b/src/alignment/data.py
@@ -175,7 +175,7 @@ def mix_datasets(
     raw_train_datasets = []
     raw_val_datasets = []
     fracs = []
-    colums_to_keep = COLUMNS_TO_KEEP if text_column is None else COLUMNS_TO_KEEP + [text_column]
+    columns_to_keep = COLUMNS_TO_KEEP if text_column is None else COLUMNS_TO_KEEP + [text_column]
     for (ds, frac), ds_config in zip(dataset_mixer.items(), configs):
         fracs.append(frac)
         for split in splits:
@@ -187,7 +187,7 @@ def mix_datasets(
                 dataset = load_from_disk(os.path.join(ds, split))
 
             # Remove redundant columns to avoid schema conflicts on load
-            dataset = dataset.remove_columns([col for col in dataset.column_names if col not in colums_to_keep])
+            dataset = dataset.remove_columns([col for col in dataset.column_names if col not in columns_to_keep])
             if "train" in split:
                 raw_train_datasets.append(dataset)
             elif "test" in split:

--- a/src/alignment/data.py
+++ b/src/alignment/data.py
@@ -97,7 +97,7 @@ def apply_chat_template(
 
 def get_datasets(
     data_config: DataArguments | dict,
-    splits: List[str] = ["train", "test"],
+    splits: Optional[List[str]] = None,
     configs: Optional[List[str]] = None,
     shuffle: bool = True,
 ) -> DatasetDict:
@@ -115,7 +115,7 @@ def get_datasets(
     Returns
         [`DatasetDict`]: The dataset dictionary containing the loaded datasets.
     """
-
+    splits = ["train", "test"] if splits is None else splits
     if type(data_config) is DataArguments:
         # Structure of the config to read the datasets and their mix
         # datasets_mixer:

--- a/src/alignment/data.py
+++ b/src/alignment/data.py
@@ -23,8 +23,6 @@ from .configs import DataArguments
 
 DEFAULT_CHAT_TEMPLATE = "{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '<|user|>\n' + message['content'] + eos_token }}\n{% elif message['role'] == 'system' %}\n{{ '<|system|>\n' + message['content'] + eos_token }}\n{% elif message['role'] == 'assistant' %}\n{{ '<|assistant|>\n'  + message['content'] + eos_token }}\n{% endif %}\n{% if loop.last and add_generation_prompt %}\n{{ '<|assistant|>' }}\n{% endif %}\n{% endfor %}"
 
-COLUMNS_TO_KEEP = ["messages", "chosen", "rejected", "prompt", "completion", "label"]
-
 
 def maybe_insert_system_message(messages, tokenizer):
     if messages[0]["role"] == "system":
@@ -171,7 +169,7 @@ def mix_datasets(
     splits = ["train", "test"] if splits is None else splits
     configs = [None] * len(dataset_mixer) if not configs else configs
     columns_to_keep = [] if columns_to_keep is None else columns_to_keep
-    
+
     if configs is not None and len(configs) != len(dataset_mixer):
         raise ValueError("The number of given dataset config names must be the same as the given number of datasets.")
 
@@ -219,7 +217,7 @@ def mix_datasets(
 
     if len(raw_datasets) == 0:
         raise ValueError(
-            f"Dataset {dataset_mixer} not recognized with split {split}. Check the dataset has been correctly formatted."
+            f"Dataset {dataset_mixer} not recognized with splits {splits}. Check the dataset has been correctly formatted."
         )
 
     return raw_datasets

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -33,7 +33,7 @@ class GetDatasetsTest(unittest.TestCase):
             "HuggingFaceH4/testing_codealpaca_small": 0.2,
         }
         data_args = DataArguments(dataset_mixer=dataset_mixer)
-        datasets = get_datasets(data_args)
+        datasets = get_datasets(data_args, columns_to_keep=["prompt", "completion"])
         self.assertEqual(len(datasets["train"]), 100)
         self.assertEqual(len(datasets["test"]), 300)
 
@@ -43,7 +43,7 @@ class GetDatasetsTest(unittest.TestCase):
             "HuggingFaceH4/testing_self_instruct_small": 0.3,
             "HuggingFaceH4/testing_codealpaca_small": 0.2,
         }
-        datasets = get_datasets(dataset_mixer)
+        datasets = get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
         self.assertEqual(len(datasets["train"]), 100)
         self.assertEqual(len(datasets["test"]), 300)
 
@@ -53,7 +53,7 @@ class GetDatasetsTest(unittest.TestCase):
             "HuggingFaceH4/testing_self_instruct_small": 1.0,
             "HuggingFaceH4/testing_codealpaca_small": 1.0,
         }
-        datasets = get_datasets(dataset_mixer)
+        datasets = get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
         self.assertEqual(len(datasets["train"]), 300)
         self.assertEqual(len(datasets["test"]), 300)
 
@@ -62,7 +62,7 @@ class GetDatasetsTest(unittest.TestCase):
             "HuggingFaceH4/testing_alpaca_small": 0.7,
             "HuggingFaceH4/testing_self_instruct_small": 0.4,
         }
-        datasets = get_datasets(dataset_mixer)
+        datasets = get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
         self.assertEqual(len(datasets["train"]), 70 + 40)
         self.assertEqual(len(datasets["test"]), 200)
 
@@ -72,13 +72,13 @@ class GetDatasetsTest(unittest.TestCase):
             "HuggingFaceH4/testing_self_instruct_small": -0.3,
         }
         with pytest.raises(ValueError, match=r"Dataset fractions cannot be negative."):
-            get_datasets(dataset_mixer)
+            get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
 
     def test_loading_single_split_with_unit_fractions(self):
         dataset_mixer = {
             "HuggingFaceH4/testing_alpaca_small": 1.0,
         }
-        datasets = get_datasets(dataset_mixer, splits=["test"])
+        datasets = get_datasets(dataset_mixer, splits=["test"], columns_to_keep=["prompt", "completion"])
         self.assertEqual(len(datasets["test"]), 100)
         self.assertRaises(KeyError, lambda: datasets["train"])
 


### PR DESCRIPTION
This PR fixes an issue introduced in this PR https://github.com/huggingface/alignment-handbook/pull/135 where "unused" columns would be removed. However, the definition of what "unused columns" are is not user-defined and therefore prone to unexpected side-effects. Moreover, this was only focused on instruction or DPO-like datasets, and did not account for pretraining datasets.

This PR makes sure that the user-defined `text_column` (that is used to collect the pretraining column) is not removed when `run_cpt.py` is used. 