### PR TITLE
fix: Zephyr LoRA fine-tuning fixed

### DIFF
--- a/recipes/zephyr-7b-beta/README.md
+++ b/recipes/zephyr-7b-beta/README.md
@@ -23,10 +23,22 @@ ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_con
 
 ## QLoRA training examples
 
-```shell
+Train faster with flash-attention 2 (GPU supporting FA2: A100, H100, etc)
+```````shell
 # Step 1 - SFT
 ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/multi_gpu.yaml --num_processes=1 scripts/run_sft.py recipes/zephyr-7b-beta/sft/config_qlora.yaml --load_in_4bit=true
 
 # Step 2 - DPO
 ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/multi_gpu.yaml --num_processes=1 scripts/run_dpo.py recipes/zephyr-7b-beta/dpo/config_qlora.yaml
-```
+```````
+
+P.S. Using Flash Attention also allows you to drastically increase the batch size (x2 in my case)
+
+Train without flash-attention:
+```````shell
+# Step 1 - SFT
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/multi_gpu.yaml --num_processes=1 scripts/run_sft.py recipes/zephyr-7b-beta/sft/config_qlora.yaml --load_in_4bit=true --use_flash_attention_2=false
+
+# Step 2 - DPO
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/multi_gpu.yaml --num_processes=1 scripts/run_dpo.py recipes/zephyr-7b-beta/dpo/config_qlora.yaml --use_flash_attention_2=false
+```````

--- a/recipes/zephyr-7b-beta/dpo/config_qlora.yaml
+++ b/recipes/zephyr-7b-beta/dpo/config_qlora.yaml
@@ -1,6 +1,7 @@
 # Model arguments
 model_name_or_path: alignment-handbook/zephyr-7b-sft-qlora
 torch_dtype: bfloat16
+use_flash_attention_2: true
 
 # LoRA arguments
 use_peft: true

--- a/recipes/zephyr-7b-beta/sft/config_qlora.yaml
+++ b/recipes/zephyr-7b-beta/sft/config_qlora.yaml
@@ -1,7 +1,8 @@
 # Model arguments
 model_name_or_path: mistralai/Mistral-7B-v0.1
 model_revision: main
-torch_dtype: float16
+torch_dtype: bfloat16
+use_flash_attention_2: true
 
 # LoRA arguments
 load_in_4bit: true


### PR DESCRIPTION
I tried using LoRA fine-tuning instead of QLoRA fine-tuning and it didn't work:
I used exactly your training config and if I train LoRA, the loss would become 0 without bf16 specified in the config.
<img width="1392" alt="image" src="https://github.com/huggingface/alignment-handbook/assets/44948570/38657bfb-f3eb-4073-9667-a717ca35d216">

With bf16 issue is resolved (I trained LoRA model for 50% of the sft data and got the expected results). Furthermore, I re-used this bf16 config for QLoRA and the results are the same as you report (~0.95 SFT loss)

Also, I added the flash attention 2 flag as it speeds up training, allows doubling the batch for QLoRA (per gpu batch size 4 -> 8) while not changing the results at all (just to be safe, I tested it too and the curves are the same)
<img width="1395" alt="image" src="https://github.com/huggingface/alignment-handbook/assets/44948570/b8d3d9b3-084e-4cd1-92f4-22874506cc3b">

P.S. in my photos, 1% means that I trained for 1% of SFT steps just to make sure the losses are identical and changing the flag does not break anything

In total, this PR fixes LoRA that didn't work before (due to loss = 0) and speeds up QLoRA & LoRA configurations by flash attention flag

