### PR TITLE
Update README.md, there is problem if it have to be flash_attn==2.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ python -m pip install .
 You will also need Flash Attention 2 installed, which can be done by running:
 
 ```shell
-python -m pip install flash-attn==2.3.6 --no-build-isolation
+python -m pip install flash-attn --no-build-isolation
 ```
 
 > **Note**
-> If your machine has less than 96GB of RAM and many CPU cores, reduce the `MAX_JOBS` arguments, e.g. `MAX_JOBS=4 pip install flash-attn==2.3.6 --no-build-isolation`
+> If your machine has less than 96GB of RAM and many CPU cores, reduce the `MAX_JOBS` arguments, e.g. `MAX_JOBS=4 pip install flash-attn --no-build-isolation`
 
 Next, log into your Hugging Face account as follows:
 


### PR DESCRIPTION
If use 2.3.6, there will be an error

ImportError: /root/miniconda3/envs/handbook/lib/python3.10/site-packages/flash_attn_2_cuda.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZN2at4_ops9_pad_enum4callERKNS_6TensorEN3c108ArrayRefINS5_6SymIntEEElNS5_8optionalIdEE

If we use the newest flash_attn version, there will be no trouble!