### PR TITLE
Fix BitsAndBytes JSON Serializable

### DIFF
--- a/scripts/run_cpt.py
+++ b/scripts/run_cpt.py
@@ -122,7 +122,7 @@ def main():
     torch_dtype = (
         model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
     )
-    quantization_config = get_quantization_config(model_args)
+    quantization_config = get_quantization_config(model_args).to_dict()
 
     model_kwargs = dict(
         revision=model_args.model_revision,

--- a/scripts/run_dpo.py
+++ b/scripts/run_dpo.py
@@ -141,7 +141,7 @@ def main():
     torch_dtype = (
         model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
     )
-    quantization_config = get_quantization_config(model_args)
+    quantization_config = get_quantization_config(model_args).to_dict()
 
     model_kwargs = dict(
         revision=model_args.model_revision,

--- a/scripts/run_orpo.py
+++ b/scripts/run_orpo.py
@@ -100,7 +100,7 @@ def main():
     torch_dtype = (
         model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
     )
-    quantization_config = get_quantization_config(model_args)
+    quantization_config = get_quantization_config(model_args).to_dict()
 
     model = AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,

--- a/scripts/run_sft.py
+++ b/scripts/run_sft.py
@@ -108,7 +108,7 @@ def main():
     torch_dtype = (
         model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
     )
-    quantization_config = get_quantization_config(model_args)
+    quantization_config = get_quantization_config(model_args).to_dict()
 
     model_kwargs = dict(
         revision=model_args.model_revision,

--- a/scripts/run_sft.py
+++ b/scripts/run_sft.py
@@ -117,7 +117,7 @@ def main():
         torch_dtype=torch_dtype,
         use_cache=False if training_args.gradient_checkpointing else True,
         device_map=get_kbit_device_map() if quantization_config is not None else None,
-        quantization_config=quantization_config,
+        quantization_config=quantization_config.to_dict(),
     )
 
     model = model_args.model_name_or_path


### PR DESCRIPTION
This PR is related to #189 

Current `transformers` tries to convert every config objects into Dictionary([link](https://github.com/huggingface/transformers/blob/e0d82534cc95b582ab072c1bbc060852ba7f9d51/src/transformers/training_args.py#L2468C6-L2468C6)), but it does not resolve in nested config case (`BitsAndBytesConfig`) with the following error. This is because `BitsAndBytesConfig` is stored under `quantization_config` of the training args:

```
TypeError: Object of type BitsAndBytesConfig is not JSON serializable
```

caused by [this(https://github.com/huggingface/transformers/blob/e0d82534cc95b582ab072c1bbc060852ba7f9d51/src/transformers/training_args.py#L2446)].

The easiest solution for this is to call `to_dict()` method after `get_quantization_config()`.