### PR TITLE
Use `get_chat_template()` instead of `default_chat_template`

### DIFF
--- a/src/alignment/model_utils.py
+++ b/src/alignment/model_utils.py
@@ -88,7 +88,7 @@ def get_tokenizer(
 
     if data_args.chat_template is not None:
         tokenizer.chat_template = data_args.chat_template
-    elif auto_set_chat_template and tokenizer.chat_template is None and tokenizer.default_chat_template is None:
+    elif auto_set_chat_template and tokenizer.get_chat_template() is None:
         tokenizer.chat_template = DEFAULT_CHAT_TEMPLATE
 
     return tokenizer


### PR DESCRIPTION
## Description

This PR updates the `get_tokenizer` function so that the default chat template is checked using the `get_chat_template` method instead of the `default_chat_template` attribute as it's not available.