### PR TITLE
Fix config file loading: require --config flag instead of positional …

### DIFF
--- a/recipes/zephyr-7b-beta/README.md
+++ b/recipes/zephyr-7b-beta/README.md
@@ -29,7 +29,7 @@ Train faster with flash-attention 2 (GPU supporting FA2: A100, H100, etc)
 ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/sft.py --config recipes/zephyr-7b-beta/sft/config_qlora.yaml --load_in_4bit=true
 
 # Step 2 - DPO
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/dpo.py recipes/zephyr-7b-beta/dpo/config_qlora.yaml
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/dpo.py --config recipes/zephyr-7b-beta/dpo/config_qlora.yaml
 ```````
 
 P.S. Using Flash Attention also allows you to drastically increase the batch size (x2 in my case)
@@ -37,8 +37,8 @@ P.S. Using Flash Attention also allows you to drastically increase the batch siz
 Train without flash-attention (i.e. via PyTorch's scaled dot product attention):
 ```````shell
 # Step 1 - SFT
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/sft.py recipes/zephyr-7b-beta/sft/config_qlora.yaml --load_in_4bit=true --attn_implementation=sdpa
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/sft.py --config recipes/zephyr-7b-beta/sft/config_qlora.yaml --load_in_4bit=true --attn_implementation=sdpa
 
 # Step 2 - DPO
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/dpo.py recipes/zephyr-7b-beta/dpo/config_qlora.yaml --attn_implementation=sdpa
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/dpo.py --config recipes/zephyr-7b-beta/dpo/config_qlora.yaml --attn_implementation=sdpa
 ```````


### PR DESCRIPTION
This PR fixes how configuration files are passed to training scripts. Some scripts are fine, while others crash.

Previously, the training yaml file (e.g. config_qlora.yaml) was provided as a positional argument (first noticed in the zephyr beta qlora DPO example):

```accelerate launch ... scripts/dpo.py recipes/zephyr-7b-beta/dpo/config_qlora.yaml```

In this case, HfArgumentParser only receives command-line flags and does not parse the config_qlora.yaml, leaving dataset_mixture=None and triggering the error:
```ValueError: Either `dataset_name` or `dataset_mixture` must be provided```

The correct usage is to pass the config file with the --config flag:
```accelerate launch ... scripts/dpo.py --config recipes/zephyr-7b-beta/dpo/config_qlora.yaml```