### PR TITLE
Do not initialise ref model when peft is used

### DIFF
--- a/scripts/dpo.py
+++ b/scripts/dpo.py
@@ -99,9 +99,9 @@ def main(script_args, training_args, model_args):
     ###################
     model = get_model(model_args, training_args)
     if model_args.use_peft:
-        ref_model = get_model(model_args, training_args)
-    else:
         ref_model = None
+    else:
+        ref_model = get_model(model_args, training_args)
     tokenizer = get_tokenizer(model_args, training_args)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token

--- a/scripts/dpo.py
+++ b/scripts/dpo.py
@@ -98,7 +98,10 @@ def main(script_args, training_args, model_args):
     # Model & Tokenizer
     ###################
     model = get_model(model_args, training_args)
-    ref_model = get_model(model_args, training_args)
+    if model_args.use_peft:
+        ref_model = get_model(model_args, training_args)
+    else:
+        ref_model = None
     tokenizer = get_tokenizer(model_args, training_args)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token


### PR DESCRIPTION
When running the DPO script with a PEFT configuration, e.g.:
```
ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/dpo.py --config recipes/zephyr-7b-beta/dpo/config_qlora.yaml
```

the following error is raised:
```ValueError: You passed both a ref_model and a peft_config. For training PEFT adapters with DPO there is no need to pass a reference model. Please pass `ref_model=None` in case you want to train PEFT adapters, or pass a ref_model with `force_use_ref_model=True` in DPOTrainer's init. if you want to use a different ref_model.```

This happens because the script tries to initialize a reference model even when LoRA/PEFT is enabled.

This PR updates the logic to skip reference model initialization when PEFT adapters are used. 

I am referring to the similar logic that is used in the trl example dpo script:

https://github.com/huggingface/trl/blob/main/trl/scripts/dpo.py#L109