### PR TITLE
Update examples to use max_length instead of deprecated max_seq_length

### DIFF
--- a/recipes/constitutional-ai/sft/config_anthropic.yaml
+++ b/recipes/constitutional-ai/sft/config_anthropic.yaml
@@ -40,7 +40,7 @@ log_level: info
 logging_steps: 5  
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 2048
+max_length: 2048
 max_steps: -1
 num_train_epochs: 1
 output_dir: data/mistral-7b-sft-constitutional-ai

--- a/recipes/constitutional-ai/sft/config_grok.yaml
+++ b/recipes/constitutional-ai/sft/config_grok.yaml
@@ -40,7 +40,7 @@ log_level: info
 logging_steps: 5  
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 2048
+max_length: 2048
 max_steps: -1
 num_train_epochs: 1
 output_dir: data/mistral-7b-sft-constitutional-ai

--- a/recipes/smollm/sft/config.yaml
+++ b/recipes/smollm/sft/config.yaml
@@ -90,7 +90,7 @@ log_level: info
 logging_steps: 5
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 2048
+max_length: 2048
 max_steps: -1
 num_train_epochs: 1
 output_dir: data/smollm-360M-instruct-new

--- a/recipes/smollm2/sft/config.yaml
+++ b/recipes/smollm2/sft/config.yaml
@@ -27,7 +27,7 @@ log_level: info
 logging_steps: 5
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 8192
+max_length: 8192
 max_steps: -1
 num_train_epochs: 2
 output_dir: data/smollm2-1.7B-sft

--- a/recipes/smollm2/sft/config_smol.yaml
+++ b/recipes/smollm2/sft/config_smol.yaml
@@ -26,7 +26,7 @@ log_level: info
 logging_steps: 5
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 8192
+max_length: 8192
 max_steps: -1
 num_train_epochs: 2
 output_dir: data/smollm2-360M-sft

--- a/recipes/starchat2-15b/sft/config_v0.1.yaml
+++ b/recipes/starchat2-15b/sft/config_v0.1.yaml
@@ -87,7 +87,7 @@ log_level: info
 logging_steps: 5
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 2048
+max_length: 2048
 max_steps: -1
 num_train_epochs: 3
 output_dir: data/starchat2-15b-v0.1

--- a/recipes/zephyr-7b-beta/sft/config_full.yaml
+++ b/recipes/zephyr-7b-beta/sft/config_full.yaml
@@ -39,7 +39,7 @@ log_level: info
 logging_steps: 5  
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 2048
+max_length: 2048
 max_steps: -1
 num_train_epochs: 1
 output_dir: data/zephyr-7b-sft-full

--- a/recipes/zephyr-7b-beta/sft/config_qlora.yaml
+++ b/recipes/zephyr-7b-beta/sft/config_qlora.yaml
@@ -54,7 +54,7 @@ log_level: info
 logging_steps: 5  
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 2048
+max_length: 2048
 max_steps: -1
 num_train_epochs: 1
 output_dir: data/zephyr-7b-sft-qlora

--- a/recipes/zephyr-7b-gemma/sft/config_full.yaml
+++ b/recipes/zephyr-7b-gemma/sft/config_full.yaml
@@ -42,7 +42,7 @@ log_level: info
 logging_steps: 5
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 2048
+max_length: 2048
 max_steps: -1
 num_train_epochs: 3
 output_dir: data/zephyr-7b-gemma-sft

--- a/scripts/sft.py
+++ b/scripts/sft.py
@@ -24,7 +24,7 @@ accelerate launch --config_file recipes/accelerate_configs/zero3.yaml scripts/sf
     --learning_rate 2.0e-5 \
     --num_train_epochs 1 \
     --packing \
-    --max_seq_length 4096 \
+    --max_length 4096 \
     --per_device_train_batch_size 2 \
     --gradient_accumulation_steps 8 \
     --gradient_checkpointing \

--- a/tests/fixtures/config_sft_full.yaml
+++ b/tests/fixtures/config_sft_full.yaml
@@ -25,7 +25,7 @@ log_level: info
 logging_steps: 5  
 logging_strategy: steps
 lr_scheduler_type: cosine
-max_seq_length: 2048
+max_length: 2048
 max_steps: -1
 num_train_epochs: 1
 output_dir: data/zephyr-7b-sft-full


### PR DESCRIPTION
This PR updates all example scripts in the Alignment Handbook to replace the deprecated max_seq_length parameter with max_length, matching the current SFTTrainer API in trl.

Context:
Recent versions of trl have renamed max_seq_length → max_length, causing example scripts to raise errors such as:

```
TypeError: SFTTrainer.__init__() got an unexpected keyword argument 'max_seq_length'
```

Changes:
	•	Updated all occurrences of max_seq_length → max_length in example scripts.
	•	No modifications to library or trainer code — only examples were adjusted for compatibility.

Impact:
Examples now run correctly with the latest trl releases, improving out-of-the-box usability.
