### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e #v2
         with:
           python-version: 3.10.10
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e #v2
         with:
           python-version: 3.10.10
       - name: Install dependencies


### PR DESCRIPTION
This PR pins GitHub Actions to exact commit SHAs for more reproducible builds.

## Why pin to commit SHAs?

Pinning GitHub Actions to specific commit SHAs ensures your workflow uses the exact same version every time, preventing unexpected changes when an action publisher releases a new version. This improves security and reliability.

Learn more: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Changes

- Pinned `actions/checkout` from `v2` to `ee0669b` in `.github/workflows/quality.yml`
- Pinned `actions/checkout` from `v2` to `ee0669b` in `.github/workflows/tests.yml`
- Pinned `actions/setup-python` from `v2` to `e9aba2c` in `.github/workflows/quality.yml`
- Pinned `actions/setup-python` from `v2` to `e9aba2c` in `.github/workflows/tests.yml`
