### PR TITLE
docs: drop duplicated word in sft.py usage comment

### DIFF
--- a/scripts/sft.py
+++ b/scripts/sft.py
@@ -17,7 +17,7 @@ Supervised fine-tuning script for decoder language models.
 
 Usage:
 
-# One 1 node of 8 x H100s
+# 1 node of 8 x H100s
 accelerate launch --config_file recipes/accelerate_configs/zero3.yaml scripts/sft.py \
     --model_name_or_path Qwen/Qwen2.5-1.5B-Instruct \
     --dataset_name trl-lib/Capybara \


### PR DESCRIPTION
The usage comment in `scripts/sft.py` says "One 1 node of 8 x H100s" — "One" and "1" are redundant. Dropping "One" so it reads "1 node of 8 x H100s".