### PR TITLE
docs: fix stale run_{task}.py script path in scripts/README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,19 +13,19 @@ In practice, we find comparable performance for both full and QLoRA fine-tuning,
 
 ```shell
 # Full training with ZeRO-3 on 8 GPUs
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/zero3.yaml scripts/run_{task}.py --config recipes/{model_name}/{task}/config_full.yaml
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/zero3.yaml scripts/{task}.py --config recipes/{model_name}/{task}/config_full.yaml
 
 # QLoRA 4-bit training on a single GPU
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/run_{task}.py --config recipes/{model_name}/{task}/config_qlora.yaml
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/{task}.py --config recipes/{model_name}/{task}/config_qlora.yaml
 
 # LoRA training on a single GPU
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/run_{task}.py --config recipes/{model_name}/{task}/config_qlora.yaml --load_in_4bit=false
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/ddp.yaml --num_processes=1 scripts/{task}.py --config recipes/{model_name}/{task}/config_qlora.yaml --load_in_4bit=false
 
 # LoRA training with ZeRO-3 on two or more GPUs
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/zero3.yaml --num_processes={num_gpus} scripts/run_{task}.py --config recipes/{model_name}/{task}/config_qlora.yaml --load_in_4bit=false
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/zero3.yaml --num_processes={num_gpus} scripts/{task}.py --config recipes/{model_name}/{task}/config_qlora.yaml --load_in_4bit=false
 
 # QLoRA training with FSDP on two or more GPUs
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/fsdp+qlora.yaml --num_processes={num_gpus} scripts/run_{task}.py --config recipes/{model_name}/{task}/config_qlora.yaml --torch_dtype=bfloat16 --bnb_4bit_quant_storage=bfloat16
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/fsdp+qlora.yaml --num_processes={num_gpus} scripts/{task}.py --config recipes/{model_name}/{task}/config_qlora.yaml --torch_dtype=bfloat16 --bnb_4bit_quant_storage=bfloat16
 ```
 
 Here `{task}` refers to the type of training you wish to run. Currently, the following tasks are supported:
@@ -50,14 +50,14 @@ By default, these scripts will push each model to your Hugging Face Hub username
 
 ```shell
 # Change batch size, number of epochs etc
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/zero3.yaml scripts/run_{task}.py --config recipes/{model_name}/{task}/config_full.yaml --per_device_train_batch_size=42 --num_train_epochs=5
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/zero3.yaml scripts/{task}.py --config recipes/{model_name}/{task}/config_full.yaml --per_device_train_batch_size=42 --num_train_epochs=5
 ```
 
 ## Logging with Weights and Biases
 By default, all training metrics are logged with TensorBoard. If you have a [Weights and Biases](https://wandb.ai/site) account and are logged in, you can view the training metrics by appending `--report_to=wandb`, e.g.
 
 ```shell
-ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/zero3.yaml scripts/run_{task}.py --config recipes/{model_name}/{task}/config_full.yaml --report_to=wandb
+ACCELERATE_LOG_LEVEL=info accelerate launch --config_file recipes/accelerate_configs/zero3.yaml scripts/{task}.py --config recipes/{model_name}/{task}/config_full.yaml --report_to=wandb
 ```
 
 ## Launching jobs on a Slurm cluster


### PR DESCRIPTION
The **General** usage template in `scripts/README.md` invokes `scripts/run_{task}.py`:

```
accelerate launch ... scripts/run_{task}.py --config recipes/{model_name}/{task}/config_full.yaml
```

But the training scripts were renamed to drop the `run_` prefix — `scripts/` now contains only `sft.py`, `dpo.py`, `orpo.py` (no `run_*.py`). Substituting a task (e.g. `sft`) gives `scripts/run_sft.py`, which fails with `No such file or directory`.

The concrete examples further down the **same file** already use the correct names (`scripts/sft.py` at line 41, `scripts/dpo.py` at line 44), as do the recipe READMEs. This updates the 7 template occurrences (`run_{task}.py` → `{task}.py`) to match.

Docs-only, no functional change.